### PR TITLE
Ensure color catalog button visible on mobile

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -49,23 +49,30 @@ const Header = () => {
             ))}
           </nav>
 
-          <div className="hidden md:flex items-center">
+          <div className="flex items-center space-x-4">
             <a
               href="/catalogo-cores.pdf"
               target="_blank"
               rel="noopener noreferrer"
-              className="bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white px-4 py-2 rounded-lg font-medium inline-block transition-colors"
+              className="hidden md:inline-block bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white px-4 py-2 rounded-lg font-medium transition-colors"
             >
               Catálogo de Cores
             </a>
+            <a
+              href="/catalogo-cores.pdf"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="md:hidden bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white px-3 py-2 rounded-lg font-medium text-sm transition-colors"
+            >
+              Catálogo de Cores
+            </a>
+            <button
+              className="md:hidden text-stone-50 hover:text-amber-500 transition-colors"
+              onClick={() => setIsMenuOpen(!isMenuOpen)}
+            >
+              {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
+            </button>
           </div>
-
-          <button
-            className="md:hidden text-stone-50 hover:text-amber-500 transition-colors"
-            onClick={() => setIsMenuOpen(!isMenuOpen)}
-          >
-            {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
-          </button>
         </div>
 
         {isMenuOpen && (

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -49,13 +49,11 @@ const Hero = () => {
             </a>
           </div>
         </div>
-      </div>
-
-      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
-        <div className="w-6 h-10 border-2 border-stone-400 rounded-full flex justify-center">
-          <div className="w-1 h-3 bg-stone-400 rounded-full mt-2"></div>
+        <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
+          <div className="w-6 h-10 border-2 border-stone-400 rounded-full flex justify-center">
+            <div className="w-1 h-3 bg-stone-400 rounded-full mt-2"></div>
+          </div>
         </div>
-      </div>
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- add mobile variant of "Catálogo de Cores" button and group with menu toggle so it stays accessible on small screens
- remove stray closing div in hero component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b78a09bbb88333afa94b4f8020fc4f