### PR TITLE
chore: bump site version to 1.0.1

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -9,8 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
-    <script type="module" crossorigin src="/assets/index-I5VTJyz-.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-D_V98FCI.css">
+    <script type="module" crossorigin src="/assets/index-C2SRs6rE.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CArBxsF1.css">
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-react-typescript-starter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-react-typescript-starter",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-react-typescript-starter",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- bump project version to 1.0.1
- rebuild dist output

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba2d39dc208333b5ea4ec88c8e0332