### PR TITLE
Fix header spacing and mobile drawer overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,15 +11,17 @@ import WhatsAppFloat from './components/WhatsAppFloat';
 
 function App() {
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen bg-stone-950 text-stone-50">
       <Header />
-      <Hero />
-      <About />
-      <Differentials />
-      <Portfolio />
-      <Testimonials />
-      <CTA />
-      <Footer />
+      <main className="pt-16">
+        <Hero />
+        <About />
+        <Differentials />
+        <Portfolio />
+        <Testimonials />
+        <CTA />
+        <Footer />
+      </main>
       <WhatsAppFloat />
     </div>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,28 +21,30 @@ const Header = () => {
   ];
 
   return (
-    <header className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-      isScrolled ? 'bg-stone-900/95 backdrop-blur-sm shadow-lg' : 'bg-transparent'
-    }`}>
-      <div className="container mx-auto px-4 sm:px-6">
-        <div className="flex items-center justify-between py-4">
+    <>
+      <header
+        className={`fixed top-0 left-0 right-0 z-50 h-16 transition-all duration-300 ${
+          isScrolled ? 'bg-stone-900/95 backdrop-blur-sm shadow-lg' : 'bg-transparent'
+        }`}
+      >
+        <div className="container mx-auto flex h-full items-center justify-between px-4 sm:px-6">
           <div className="flex items-center">
             <img
               src="/logo.png"
               alt="GRD MAD Logo"
-              className="h-12 w-auto mr-3 object-contain"
+              className="mr-3 h-12 w-auto object-contain"
             />
             <div className="text-2xl font-bold text-stone-50">
               GRD <span className="text-amber-500">MAD</span>
             </div>
           </div>
 
-          <nav className="hidden md:flex items-center space-x-8">
+          <nav className="hidden items-center space-x-8 md:flex">
             {menuItems.map((item) => (
               <a
                 key={item.label}
                 href={item.href}
-                className="text-stone-100 hover:text-amber-500 transition-colors duration-200"
+                className="text-stone-100 transition-colors duration-200 hover:text-amber-500"
               >
                 {item.label}
               </a>
@@ -54,45 +56,58 @@ const Header = () => {
               href="/catalogo-cores.pdf"
               target="_blank"
               rel="noopener noreferrer"
-              className="hidden md:inline-block bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white px-4 py-2 rounded-lg font-medium transition-colors"
+              className="hidden rounded-lg bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 px-4 py-2 font-medium text-white transition-colors hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 md:inline-block"
             >
               Catálogo de Cores
             </a>
             <button
-              className="md:hidden text-stone-50 hover:text-amber-500 transition-colors"
+              type="button"
+              className="text-stone-50 transition-colors hover:text-amber-500 md:hidden"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
+              aria-label={isMenuOpen ? 'Fechar menu' : 'Abrir menu'}
+              aria-expanded={isMenuOpen}
             >
               {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
             </button>
           </div>
         </div>
+      </header>
 
-        {isMenuOpen && (
-          <div className="md:hidden pb-4 space-y-4">
-            <nav className="flex flex-col space-y-4">
-              {menuItems.map((item) => (
-                <a
-                  key={item.label}
-                  href={item.href}
-                  className="text-stone-100 hover:text-amber-500 transition-colors duration-200"
-                  onClick={() => setIsMenuOpen(false)}
-                >
-                  {item.label}
-                </a>
-              ))}
-            </nav>
-            <a
-              href="/catalogo-cores.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block text-center bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600 text-white px-4 py-2 rounded-lg font-medium transition-colors"
-            >
-              Catálogo de Cores
-            </a>
+      {isMenuOpen && (
+        <div className="fixed inset-x-0 top-16 bottom-0 z-40 md:hidden">
+          <div className="relative h-full">
+            <button
+              type="button"
+              aria-label="Fechar menu"
+              className="absolute inset-0 bg-black/40"
+              onClick={() => setIsMenuOpen(false)}
+            />
+            <div className="relative z-10 ml-auto flex h-full w-72 flex-col border-l border-stone-800 bg-stone-950/95 px-6 py-8 backdrop-blur-md">
+              <nav className="flex flex-1 flex-col space-y-6">
+                {menuItems.map((item) => (
+                  <a
+                    key={item.label}
+                    href={item.href}
+                    className="text-lg text-stone-100 transition-colors duration-200 hover:text-amber-500"
+                    onClick={() => setIsMenuOpen(false)}
+                  >
+                    {item.label}
+                  </a>
+                ))}
+              </nav>
+              <a
+                href="/catalogo-cores.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-6 block rounded-lg bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 px-4 py-3 text-center font-medium text-white transition-colors hover:from-pink-600 hover:via-purple-600 hover:to-indigo-600"
+              >
+                Catálogo de Cores
+              </a>
+            </div>
           </div>
-        )}
-      </div>
-    </header>
+        </div>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- give the header a fixed 64px height and pad the main content so sections begin below it
- replace the stacked mobile menu with an overlay drawer that opens below the header without pushing the layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd71fdb0608333a6337196d2b026f2