### PR TITLE
Fix swarm deployment to use image-provided assets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,6 @@ services:
         - traefik.http.services.grdmad.loadbalancer.server.port=80
 
 
-    # Use caminho ABSOLUTO no Swarm (recomendado)
-    volumes:
-      - /var/www/grd-mad/dist:/usr/share/nginx/html:ro
-
     networks:
       - network_public
 


### PR DESCRIPTION
## Summary
- remove the bind-mount that overwrote the container's built assets so the swarm deployment runs the freshly built image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e09b8d60748333838b0ae39aac71b2